### PR TITLE
Update gradle & travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
     - oraclejdk8
-    - oraclejdk7
 
 # the below keeps 'gradle assemble' from being called which tries to sign the jars.
 install: /bin/true

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,9 @@ String srcGeneratedDir = 'src/generated'
 String srcGeneratedJavaDir = srcGeneratedDir + '/java'
 String schemasDir = srcGeneratedDir + "/schemas"
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+//use Java 8 to compile
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 sourceSets {
     main {
@@ -63,10 +64,10 @@ configurations {
 
 dependencies {
     xjc 'javax.activation:activation:1.2.0'
-    xjc 'com.sun.xml.bind:jaxb-impl:2.3.2'
+    xjc 'com.sun.xml.bind:jaxb-impl:2.2.5-2'
     xjc 'javax.xml:jsr173:1.0'
     xjc 'stax:stax-api:1.0.1'
-    xjc 'javax.xml.bind:jaxb-api:2.3.1'
+    xjc 'javax.xml.bind:jaxb-api:2.2.11'
     xjc 'com.sun.xml.bind:jaxb-xjc:2.2.5-2'
 
     // use the JAXB2 Commons project to include some XJC plugins
@@ -82,7 +83,7 @@ dependencies {
     // with XML namespace URIs.
     xjc 'org.jvnet.jaxb2_commons:jaxb2-namespace-prefix:1.1'    
 
-    compile 'javax.xml.bind:jaxb-api:2.3.1'
+    compile 'javax.xml.bind:jaxb-api:2.2.11'
     compile 'org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.6.5'
     compile 'net.sf.saxon:Saxon-HE:9.5.1-5'
     compile 'org.apache.httpcomponents:httpclient:4.3.5' 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'signing'
 
 defaultTasks 'jar'
 
-version = "1.1.0.1"
+version = "1.1.0.2"
 // version = "0.1"
 group = "org.mitre.taxii"
 archivesBaseName = "taxii"
@@ -62,11 +62,11 @@ configurations {
 }
 
 dependencies {
-    xjc 'javax.activation:activation:1.1.1'
-    xjc 'com.sun.xml.bind:jaxb-impl:2.2.5-2'
+    xjc 'javax.activation:activation:1.2.0'
+    xjc 'com.sun.xml.bind:jaxb-impl:2.3.2'
     xjc 'javax.xml:jsr173:1.0'
     xjc 'stax:stax-api:1.0.1'
-    xjc 'javax.xml.bind:jaxb-api:2.2.11'
+    xjc 'javax.xml.bind:jaxb-api:2.3.1'
     xjc 'com.sun.xml.bind:jaxb-xjc:2.2.5-2'
 
     // use the JAXB2 Commons project to include some XJC plugins
@@ -82,7 +82,7 @@ dependencies {
     // with XML namespace URIs.
     xjc 'org.jvnet.jaxb2_commons:jaxb2-namespace-prefix:1.1'    
 
-    compile 'javax.xml.bind:jaxb-api:2.2.11'
+    compile 'javax.xml.bind:jaxb-api:2.3.1'
     compile 'org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.6.5'
     compile 'net.sf.saxon:Saxon-HE:9.5.1-5'
     compile 'org.apache.httpcomponents:httpclient:4.3.5' 


### PR DESCRIPTION
1. Use Java 8 to compile.
2. Update jax activation dependency.
3. Leave others intact since we do not package them and they introduce breaking changes during compilation,